### PR TITLE
feat(spin.toml): Support templates in sub-directories

### DIFF
--- a/spin.toml
+++ b/spin.toml
@@ -6,7 +6,7 @@ trigger = { type = "http", base = "/" }
 
 [[component]]
 id = "bartholomew"
-files = [ "content/**/*" , "templates/*", "scripts/*", "config/*", "shortcodes/*"]
+files = [ "content/**/*" , "templates/**/*", "scripts/*", "config/*", "shortcodes/*"]
 [component.source]
 url = "https://github.com/fermyon/bartholomew/releases/download/v0.6.0/bartholomew.wasm"
 digest = "sha256:b64bc17da4484ff7fee619ba543f077be69b3a1f037506e0eeee1fb020d42786"


### PR DESCRIPTION
This is alreay supported out of the box by Bartholomew, we just need to properly include the files in the spin.toml